### PR TITLE
ssl env config load string val

### DIFF
--- a/src/app/providers/DatabaseProvider.js
+++ b/src/app/providers/DatabaseProvider.js
@@ -42,7 +42,7 @@ class DatabaseProvider extends Provider {
     }
 
     static ssl(){
-        if(db_conf.ssl === true){
+        if(db_conf.ssl === 'true'){
             return {
                 dialectOptions: {
                     ssl: {

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -7,6 +7,6 @@ module.exports =  {
     username:   env.DB_USERNAME,
     password:   env.DB_PASSWORD,
     database:   env.DB_DATABASE,
-    ssl:        env.DB_SSL ?? false,
+    ssl:        env?.DB_SSL ? env.DB_SSL : 'true',
     logging:    false, //!!must be either console.log or false.
 }

--- a/src/config/logging.js
+++ b/src/config/logging.js
@@ -5,7 +5,7 @@ module.exports =  {
     exclude: {
         env: ['production','test']
     },
-    stack: ['daily','slack'],
+    stack: ['console','daily','slack'],
     single: {
         level: 'critical',
     },


### PR DESCRIPTION
fixed issue where database provider was checking for boolean value but .env vals are ALWAYS strings, causing the check to fail if set to true

